### PR TITLE
Fix rights issue on init

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -4,6 +4,7 @@ on: [create, workflow_dispatch]
 
 permissions: 
   issues: write
+  contents: read
 
 jobs:
   initialize_repo:


### PR DESCRIPTION
When the target organization has the GITHUB_TOKEN setup to 'read only', the init workflow fails because it does not have the rights to checkout the code, which in turn is needed to run the GitHub CLI commands. This PR fixes those rights.