### PR TITLE
Corrected link for reusable workflows HOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Please follow [these instructions](GettingReady.md) and make sure you have set u
 - [ ] Action policies
 - [ ] Running your workflows
 - [ ] Sharing workflows
-- [ ] 🔨 Hands-on: [Reusable workflows](hol/04_Reusable-workflows.md)
+- [ ] 🔨 Hands-on: [Reusable workflows](hol/04-Reusable-workflows.md)
 - [ ] Best practices and security
 
 


### PR DESCRIPTION
There is a small error on the link for the reusable workflows hands-on in the README file.