### PR TITLE
Clarify HOL3 based on participant feedback

### DIFF
--- a/hol/03-Staged-deployments.md
+++ b/hol/03-Staged-deployments.md
@@ -25,7 +25,8 @@ This hands on lab is based on [My first workflow](01-My-first-workflow.md) and a
 
 ## Adding a input for picking environments to manual workflow trigger
 
-Add a input of the type environment to the `workflow_dispatch` trigger.
+Modify the workflow yml file you created in hands on lab 1 ('My first workflow').
+Add an input of the type environment to the `workflow_dispatch` trigger that you created previously.
 
 <details>
   <summary>Solution</summary>


### PR DESCRIPTION
A participant offered the following feedback:

> 03-Staged-deployments.md
>
> “Add a input of the type environment to the workflow_dispatch trigger.”
>
> I am not so familiar with GitHub. Therefore, I searched for a place (Button, section, etc.) for the triggers. Maybe a small
remainder that the triggers are predefined can be helpful)
>
> Also, you don’t mention in which file we should add this. I was confused because multiple files in the “workflows” directory
contains this trigger.



I added a small clarification to avoid future confusion,