### PR TITLE
Adding Link to Parent Template Repository in HOL 1

### DIFF
--- a/hol/01-My-first-workflow.md
+++ b/hol/01-My-first-workflow.md
@@ -9,7 +9,7 @@ This hands on lab consists of the following steps:
 
 ## Creating a repository
 
-Go to [this repsitory](https://github.com/ps-actions-sandbox/ActionsFundamentals) and click `Use this template`:
+Go to [The ActionsFundamentals repository in the ps-actions-sandbox organization](https://github.com/ps-actions-sandbox/ActionsFundamentals) and click <kbd>Use this template</kbd>:
 
 <img width="400" alt="2022-09-18_11-24-58" src="https://user-images.githubusercontent.com/5276337/190895393-6fa0fad9-e05c-4fea-8126-a291b087d663.png">
 

--- a/hol/01-My-first-workflow.md
+++ b/hol/01-My-first-workflow.md
@@ -9,7 +9,7 @@ This hands on lab consists of the following steps:
 
 ## Creating a repository
 
-Go to [Code](/../../) tab of this repository and click `Use this template`:
+Go to [this repsitory](https://github.com/ps-actions-sandbox/ActionsFundamentals) and click `Use this template`:
 
 <img width="400" alt="2022-09-18_11-24-58" src="https://user-images.githubusercontent.com/5276337/190895393-6fa0fad9-e05c-4fea-8126-a291b087d663.png">
 


### PR DESCRIPTION
This pull request includes a change to the `01-My-first-workflow.md` file in the `hol` directory. The change updates the link in the "Creating a repository" section to directly point to the `ActionsFundamentals` template repository instead of the generic `Code` tab.

> This avoids the need to make the training repository, created from the template, to be changed to a template itself.